### PR TITLE
🔧 tweaked iTerm theme black-bright color for better visibility

### DIFF
--- a/iterm2/monokai_tasty.itermcolors
+++ b/iterm2/monokai_tasty.itermcolors
@@ -189,13 +189,13 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.14901961386203766</real>
+    <real>0.94509804248809814</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.14901961386203766</real>
+    <real>0.84705883264541626</real>
 		<key>Red Component</key>
-		<real>0.14901961386203766</real>
+    <real>0.38431373238563538</real>
 	</dict>
 	<key>Ansi 9 Color</key>
 	<dict>


### PR DESCRIPTION
Thank you so much for making this, I really enjoy the look and feel of this theme! The reason I am making this pull request is that I ran into something that I figure other devs might also run into. I use Gulp to compile my sass files and I usually have a pane open with it running in the background, but I noticed after applying this theme:

![screen shot 2018-12-17 at 5 58 26 pm](https://user-images.githubusercontent.com/15125965/50121697-8e8b8880-0227-11e9-95a9-20f77550c9ab.png)

(for clarity, the time the task is running is supposed to be in those brackets)

so, I went ahead and changed it to something brighter, and just used the same blue used elsewhere in the theme:

![screen shot 2018-12-17 at 6 00 39 pm](https://user-images.githubusercontent.com/15125965/50121833-06f24980-0228-11e9-99e1-6085c1cad370.png)
 I tried the other colors too, but I felt this was most consistent with the rest of the theme. Let me know what you think, if you think it should be another color, I'd be happy to change it! 🙂
