### PR TITLE
Add basic clojure improvements

### DIFF
--- a/colors/vim-monokai-tasty.vim
+++ b/colors/vim-monokai-tasty.vim
@@ -315,6 +315,11 @@ call Highlight("styledXmlRegionNoise", s:white, s:none, s:none)
 call Highlight("jsonKeyword", s:light_blue, s:none, s:none)
 call Highlight("jsonString", s:yellow, s:none, s:none)
 
+" Clojure highlighting
+call Highlight("clojureParen", s:white, s:none, s:none)
+call Highlight("clojureDefine", s:light_blue, s:none, s:italic)
+call Highlight("clojureMacro", s:light_blue, s:none, s:none)
+
 " NERDTree highlighting
 call Highlight("NERDTreeClosable", s:yellow, s:none, s:none)
 call Highlight("NERDTreeOpenable", s:yellow, s:none, s:none)


### PR DESCRIPTION
I've been doing some clojure lately and I noticed that in comparison with Sublime Text clojure highlighting, things were a little off. Primarily, the parens were pretty red and there were some places where things could be colored differently.

**Sublime Version**
<img width="526" alt="screen shot 2018-12-20 at 10 15 16 am" src="https://user-images.githubusercontent.com/238929/50300645-4bf1c800-0442-11e9-81dc-bc58a10108fb.png">

**Before this PR**
<img width="585" alt="screen shot 2018-12-20 at 10 17 40 am" src="https://user-images.githubusercontent.com/238929/50300585-177e0c00-0442-11e9-8957-0babb301b324.png">

To attempt to make things look a little more like sublime, I made the changes in this PR. They get things closer to sublime but due to the clojure syntax highlighting groups (and the dynamic nature of a lisp), it's difficult to highlight things as well as Sublime Text here.

**After this PR**
<img width="606" alt="screen shot 2018-12-20 at 10 26 38 am" src="https://user-images.githubusercontent.com/238929/50300621-38def800-0442-11e9-915d-f8154bd4fb55.png">

