### PR TITLE
Added hint to settings order under .vimrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Plug 'elzr/vim-json'
 
 ## :wolf: Use
 
-Add the following to your `.vimrc`:
+Add the following to your `.vimrc` (after the Plug declaration):
 ```vim
 colorscheme vim-monokai-tasty
 ```


### PR DESCRIPTION
This helps avoiding loading issues when the colorscheme is set before the plugin is loaded.