### PR TITLE
differentiates search colors

### DIFF
--- a/colors/vim-monokai-tasty.vim
+++ b/colors/vim-monokai-tasty.vim
@@ -142,7 +142,7 @@ call Highlight("gitcommitSummary", s:white, s:none, s:none)
 call Highlight("gitcommitOverflow", s:magenta, s:none, s:none)
 
 call Highlight("SpecialKey", s:dark_grey, s:darker_grey, s:none)
-call Highlight("IncSearch", s:black, s:bright_yellow, s:bold)
+call Highlight("IncSearch", s:bright_yellow, s:black, s:bold)
 call Highlight("Search", s:black, s:bright_yellow, s:bold)
 
 call Highlight("Identifier", s:light_blue, s:none, s:none)

--- a/colors/vim-monokai-tasty.vim
+++ b/colors/vim-monokai-tasty.vim
@@ -142,7 +142,7 @@ call Highlight("gitcommitSummary", s:white, s:none, s:none)
 call Highlight("gitcommitOverflow", s:magenta, s:none, s:none)
 
 call Highlight("SpecialKey", s:dark_grey, s:darker_grey, s:none)
-call Highlight("IncSearch", s:bright_yellow, s:black, s:bold)
+call Highlight("IncSearch", s:bright_yellow, s:black, s:bold_underline)
 call Highlight("Search", s:black, s:bright_yellow, s:bold)
 
 call Highlight("Identifier", s:light_blue, s:none, s:none)


### PR DESCRIPTION
Differentiating between Search and IncSearch colors improves experience. This change adds a distinct color-set for the 'current search position' within the set of (search) highlights. Without two sets of colors, the 'current search position' is not distinguishable from other highlights in an incremental search. Further, this change helps orient the user during a search and replace (:%s/\<find\>/\<replace\>/gc) with many matches.

Specifically, IncSearch colors are inverted from Search and have an underline.