### PR TITLE
Color `helpOption` in light blue

### DIFF
--- a/colors/vim-monokai-tasty.vim
+++ b/colors/vim-monokai-tasty.vim
@@ -501,6 +501,7 @@ call Highlight('vimParenSep', { 'fg': s:white, 'bg': s:none, 'style': s:bold })
 call Highlight('vimOperParen', { 'fg': s:light_blue, 'bg': s:none, 'style': s:italic })
 call Highlight('vimUserFunc', { 'fg': s:purple, 'bg': s:none, 'style': s:none })
 call Highlight('vimFunction', { 'fg': s:orange, 'bg': s:none, 'style': s:none })
+call Highlight('helpOption', { 'fg': s:light_blue, 'bg': s:none, 'style': s:none })
 " }}}
 
 " XML {{{


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/1281e47a-b8ff-4099-92f7-62659e98d013)


After:
![After](https://github.com/user-attachments/assets/7d80d208-8370-4ff1-98c0-d4a1e9f3c414)

I chose light blue to follow with `helpHyperTextJump` as is also done in built-in themes such as `delek`